### PR TITLE
Fix links to chapters

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,30 +6,31 @@ This is based on the posts I wrote on Medium, [https://medium.com/learning-rust]
 
 #### 01. RUST BASICS
 
-1. [Why Rust?](01. why_rust.html)
-2. [Installation](02. installation.html)
-3. [Hello World](03. hello_world.html)
-4. [Cargo, Crates and Basic Project Structure](04. cargo,_crates_and_basic_project_structure.html)
-5. [Comments and Documenting the code](05. comments_and_documenting_the_code.html)
-6. [Variable bindings , Constants & Statics](06. variable_bindings_,_constants_&_statics.html)
-7. [Functions](07. functions.html)
-8. [Primitive Data Types](08. primitive_data_types.html)
-9. [Operators](09. operators.html)
-10. [Control Flows](10. control_flows.html)
+
+1. [Why Rust?](01.%20why_rust.md)
+2. [Installation](02.%20installation.md)
+3. [Hello World](03.%20hello_world.md)
+4. [Cargo, Crates and Basic Project Structure](04.%20cargo,_crates_and_basic_project_structure.md)
+5. [Comments and Documenting the code](05.%20comments_and_documenting_the_code.md)
+6. [Variable bindings , Constants & Statics](06.%20variable_bindings_,_constants_&_statics.md)
+7. [Functions](07.%20functions.md)
+8. [Primitive Data Types](08.%20primitive_data_types.md)
+9. [Operators](09.%20operators.md)
+10. [Control Flows](10.%20control_flows.md)
 
 #### 02. RUST : BEYOND THE BASICS
 
-1. [Vectors](11. vectors.html)
-2. [Structs](12. structs.html)
-3. [Enums](13. enums.html)
-4. [Generics](14. generics.html)
-5. [Impls & Traits](15. Impls_and_traits.html)
+1. [Vectors](11.%20vectors.md)
+2. [Structs](12.%20structs.md)
+3. [Enums](13.%20enums.md)
+4. [Generics](14.%20generics.md)
+5. [Impls & Traits](15.%20Impls_and_traits.md)
 
 #### 03. RUST : THE TOUGH PART
 
-1. [Ownership](16. ownership.html)
-2. [Borrowing](17. borrowing.html)
-3. [Lifetimes](18. lifetimes.html)
+1. [Ownership](16.%20ownership.md)
+2. [Borrowing](17.%20borrowing.md)
+3. [Lifetimes](18.%20lifetimes.md)
 
 
 


### PR DESCRIPTION
Thought it might be helpful to support navigation to each chapter from the `README.md`.
The reason why it didn't work before was, that spaces need to be encoded to be recognized by the Markdown formatter. 
Alternatively, you could remove the spaces from the filenames if you like. 😊 